### PR TITLE
fix: /signup/complete 페이지 - 동적 렌더링 강제, client.ts - 서버 리다이렉트 제거

### DIFF
--- a/src/app/signup/complete/page.tsx
+++ b/src/app/signup/complete/page.tsx
@@ -15,6 +15,8 @@ import Cta from '@common/components/btn/Cta/Cta.client';
 
 import { getUsersMeOptions } from '@features/sign/api/user';
 
+export const dynamic = 'force-dynamic';
+
 export default function SignupCompletePage() {
   const router = useRouter();
 

--- a/src/app/signup/complete/page.tsx
+++ b/src/app/signup/complete/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
@@ -15,11 +17,29 @@ import Cta from '@common/components/btn/Cta/Cta.client';
 
 import { getUsersMeOptions } from '@features/sign/api/user';
 
-export const dynamic = 'force-dynamic';
-
 export default function SignupCompletePage() {
-  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
 
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <div>
+        <DefaultNavbar />
+        <main className="mt-32pxr p-16pxr flex flex-col items-center">
+          <div className="h-[279px]" />
+        </main>
+      </div>
+    );
+  }
+
+  return <SignupCompleteContent />;
+}
+
+function SignupCompleteContent() {
+  const router = useRouter();
   const { data: userData } = useSuspenseQuery(getUsersMeOptions());
 
   return (

--- a/src/common/libs/api/client.ts
+++ b/src/common/libs/api/client.ts
@@ -1,7 +1,5 @@
 'use client';
 
-import { redirect } from 'next/navigation';
-
 import { deleteCookie, getCookie } from 'cookies-next';
 import { Options } from 'ky';
 import { z } from 'zod';
@@ -27,10 +25,9 @@ const authenticatedKy = baseApi.extend({
         if (response.status === 401) {
           deleteCookie('accessToken');
           deleteCookie('refreshToken');
+          // 클라이언트 환경에서만 리다이렉트
           if (typeof window !== 'undefined') {
             window.location.href = ROUTES.SIGN_IN;
-          } else {
-            redirect(ROUTES.SIGN_IN);
           }
         }
       },


### PR DESCRIPTION
## 1️⃣ 작업 내용

/signup/complete 페이지 - 동적 렌더링 강제, client.ts - 서버 리다이렉트 제거

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [ ] `main, develop` 브랜치의 최신 코드를 `pull` 받았나요?
