### PR TITLE
[🚑 Hotfix] not-found 페이지 설정

### DIFF
--- a/src/app/(events)/[eventId]/page.tsx
+++ b/src/app/(events)/[eventId]/page.tsx
@@ -1,10 +1,14 @@
 import { Suspense } from 'react';
 
+import { notFound } from 'next/navigation';
+
 import { HydrationBoundary } from '@tanstack/react-query';
 
 import queryKeys from '@common/constants/queryKeys';
 
 import getDehydratedState from '@common/libs/react-query/dehydrate';
+
+import { isPositiveNumber } from '@common/utils/isNumber';
 
 import DeferredLoader from '@common/components/DeferredLoader/DeferredLoader.client';
 
@@ -15,6 +19,12 @@ import ImageSlider from '@features/events/components/ImageSlider/ImageSlider.cli
 
 const EventDetailPage = async ({ params }: { params: Promise<{ [key: string]: string }> }) => {
   const { eventId } = await params;
+
+  // eventId가 양수로 변환 가능한지 확인
+  // 안되면 404 띄우기
+  if (!isPositiveNumber(eventId)) {
+    notFound();
+  }
 
   const { dehydratedState } = await getDehydratedState({
     prefetch: async (qc) =>

--- a/src/common/constants/routes.ts
+++ b/src/common/constants/routes.ts
@@ -16,4 +16,5 @@ export const ROUTES = {
     },
   },
   SIGNUP_COMPLETE: '/signup/complete',
+  NOT_FOUND: '/not-found', // 실제로 없는 주소 - 404 페이지 수동으로 띄우기 위해
 } as const;

--- a/src/common/libs/api/common.ts
+++ b/src/common/libs/api/common.ts
@@ -1,5 +1,9 @@
-import ky, { Options } from 'ky';
+import { notFound } from 'next/navigation';
+
+import ky, { HTTPError, Options } from 'ky';
 import { z } from 'zod';
+
+import { ROUTES } from '@common/constants/routes';
 
 import { apiResponseSchema, failSchema } from '@common/schemas/api';
 
@@ -50,27 +54,37 @@ export const fetcher = async <T extends z.ZodTypeAny>(
     apiInstance = baseApi;
   }
 
-  const cleanedUrl = url.startsWith('/') ? url.substring(1) : url;
-  const response = await apiInstance(cleanedUrl, options as Options).json();
+  try {
+    // 성공적인 응답(2xx)을 JSON으로 변환
+    const response = await apiInstance(url, options as Options).json();
 
-  // api 응답 스키마로 먼저 검증
-  const result = apiResponseSchema(schema).safeParse(response);
-  if (!result.success) {
-    console.error('API 응답 형식이 올바르지 않습니다:', result.error);
-    throw new Error('API 응답 형식이 올바르지 않습니다.');
-  }
+    // api 응답 스키마로 먼저 검증
+    const result = apiResponseSchema(schema).safeParse(response);
+    if (!result.success) {
+      console.error('API 응답 형식이 올바르지 않습니다:', result.error);
+      throw new Error('API 응답 형식이 올바르지 않습니다.');
+    }
 
-  const responseData = result.data;
-  // 실패 응답일 경우 에러 데이터를 포함하여 에러를 던짐
-  if (!responseData.status) {
-    const errorData = (responseData as z.infer<typeof failSchema>).error;
-    throw new ApiError(errorData.errorCode, errorData.reason, errorData.data);
-  }
+    const responseData = result.data;
+    // 실패 응답일 경우 에러 데이터를 포함하여 에러를 던짐
+    if (!responseData.status) {
+      const errorData = (responseData as z.infer<typeof failSchema>).error;
+      throw new ApiError(errorData.errorCode, errorData.reason, errorData.data);
+    }
 
-  // 성공 응답이면 response.data 반환
-  if ('data' in responseData) {
-    const validatedData = schema.parse(responseData.data);
-    return validatedData;
+    // 성공 응답이면 response.data 반환
+    if ('data' in responseData) {
+      const validatedData = schema.parse(responseData.data);
+      return validatedData;
+    }
+    throw new Error('Response data가 없습니다.');
+  } catch (error) {
+    // 404 에러 처리
+    if (error instanceof HTTPError && error.response.status === 404) {
+      notFound();
+    }
+
+    // 다른 에러는 그대로 throw
+    throw error;
   }
-  throw new Error('Response data가 없습니다.');
 };

--- a/src/common/utils/isNumber.ts
+++ b/src/common/utils/isNumber.ts
@@ -1,0 +1,15 @@
+/**
+ * eventId가 숫자로 변환 가능한지 확인
+ */
+export function isPositiveNumber(val: string | number | bigint) {
+  // Number()로 변환 가능한지 확인
+  const num = Number(val);
+
+  // 숫자로 변환되지 않거나 (isNaN), 유한한 숫자가 아닐 때 (Infinity 등) false 반환
+  if (isNaN(num) || !Number.isFinite(num)) {
+    return false;
+  }
+
+  // 0보다 큰지 확인
+  return num > 0;
+}

--- a/src/common/utils/isNumber.ts
+++ b/src/common/utils/isNumber.ts
@@ -10,6 +10,11 @@ export function isPositiveNumber(val: string | number | bigint) {
     return false;
   }
 
+  // 정수인지 확인
+  if (!Number.isInteger(num)) {
+    return false;
+  }
+
   // 0보다 큰지 확인
   return num > 0;
 }

--- a/src/features/events/constants/apiEndPoints.ts
+++ b/src/features/events/constants/apiEndPoints.ts
@@ -1,5 +1,5 @@
 export const EVENTS_API_ENDPOINTS = {
-  TEST_TOKEN: 'v1/auth/test-token', // 테스트용
-  EVENTS: 'v1/events',
-  EVENT_DETAIL: (eventId: string) => `v1/events/${eventId}`,
+  TEST_TOKEN: 'auth/test-token', // 테스트용
+  EVENTS: 'events',
+  EVENT_DETAIL: (eventId: string) => `events/${eventId}`,
 } as const;


### PR DESCRIPTION
## 1️⃣ 작업 내용

- resolved #51

- 양수인지 판별하는 `isPositiveNumber` 유틸함수 추가함
- `fetcher` 에서 HTTP 404 응답 받으면 not found 띄우도록 처리함

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `main, develop` 브랜치의 최신 코드를 `pull` 받았나요?
